### PR TITLE
Fix missing Dockerfile/Conda dependencies

### DIFF
--- a/buildout/ncwms2/Makefile
+++ b/buildout/ncwms2/Makefile
@@ -13,8 +13,9 @@ OS_NAME := $(shell uname -s 2>/dev/null || echo "unknown")
 CPU_ARCH := $(shell uname -m 2>/dev/null || uname -p 2>/dev/null || echo "unknown")
 
 # Python
-SETUPTOOLS_VERSION := 27.2.0
-CONDA_VERSION := 4.3.23
+SETUPTOOLS_VERSION := 36.4.0
+CONDA_VERSION := 4.4.0
+PYTHON_VERSION_MAJOR := 3
 
 # Anaconda
 ANACONDA_HOME ?= $(HOME)/anaconda
@@ -31,7 +32,13 @@ OUTPUT_PORT ?= 8090
 # choose anaconda installer depending on your OS
 ANACONDA_URL = https://repo.continuum.io/miniconda
 ifeq "$(OS_NAME)" "Linux"
+ifeq "$(PYTHON_VERSION_MAJOR)" "2"
 FN := Miniconda2-latest-Linux-x86_64.sh
+else ifeq "$(PYTHON_VERSION_MAJOR)" "3"
+FN := Miniconda3-latest-Linux-x86_64.sh
+else
+FN := unknown
+endif
 else ifeq "$(OS_NAME)" "Darwin"
 FN := Miniconda2-latest-MacOSX-x86_64.sh
 else
@@ -90,15 +97,16 @@ version:
 .PHONY: info
 info:
 	@echo "Informations about your Bird:"
-	@echo "  OS_NAME             $(OS_NAME)"
-	@echo "  CPU_ARCH            $(CPU_ARCH)"
-	@echo "  Anaconda Home       $(ANACONDA_HOME)"
-	@echo "  Conda Environment   $(CONDA_ENV). Use \`source activate $(CONDA_ENV)' to activate it."
-	@echo "  Conda Prefix        $(CONDA_ENV_PATH)"
-	@echo "  APP_NAME            $(APP_NAME)"
-	@echo "  APP_ROOT            $(APP_ROOT)"
-	@echo "  DOWNLOAD_CACHE      $(DOWNLOAD_CACHE)"
-	@echo "  DOCKER_IMAGE        $(DOCKER_IMAGE)"
+	@echo "  OS_NAME              = $(OS_NAME)"
+	@echo "  CPU_ARCH             = $(CPU_ARCH)"
+	@echo "  Anaconda Home        = $(ANACONDA_HOME)"
+	@echo "  Python Version Major = $(PYTHON_VERSION_MAJOR)"
+	@echo "  Conda Environment    = $(CONDA_ENV). Use \`source activate $(CONDA_ENV)' to activate it."
+	@echo "  Conda Prefix         = $(CONDA_ENV_PATH)"
+	@echo "  APP_NAME             = $(APP_NAME)"
+	@echo "  APP_ROOT             = $(APP_ROOT)"
+	@echo "  DOWNLOAD_CACHE       = $(DOWNLOAD_CACHE)"
+	@echo "  DOCKER_IMAGE         = $(DOCKER_IMAGE)"
 
 ## Helper targets ... ensure that Makefile etc are in place
 

--- a/buildout/ncwms2/Makefile
+++ b/buildout/ncwms2/Makefile
@@ -14,7 +14,7 @@ CPU_ARCH := $(shell uname -m 2>/dev/null || uname -p 2>/dev/null || echo "unknow
 
 # Python
 SETUPTOOLS_VERSION := 27.2.0
-CONDA_VERSION := 4.2.13
+CONDA_VERSION := 4.3.23
 
 # Anaconda
 ANACONDA_HOME ?= $(HOME)/anaconda

--- a/buildout/ncwms2/Makefile.config.example
+++ b/buildout/ncwms2/Makefile.config.example
@@ -1,3 +1,3 @@
-# Anaconda 
+# Anaconda
 ANACONDA_HOME ?= /opt/anaconda
 CONDA_ENVS_DIR ?= /opt/anaconda/envs

--- a/buildout/ncwms2/buildout.cfg
+++ b/buildout/ncwms2/buildout.cfg
@@ -47,7 +47,7 @@ recipe = collective.recipe.environment
 recipe = birdhousebuilder.recipe.ncwms
 name = ncwms
 # conda
-channels = defaults birdhouse
+channels = defaults birdhouse conda-forge
 pkgs =
      ncwms2=2.2.8
 # deployment

--- a/buildout/ncwms2/buildout.cfg
+++ b/buildout/ncwms2/buildout.cfg
@@ -4,7 +4,7 @@ extends = versions.cfg
 # buildout options
 versions = versions
 show-picked-versions = true
-newest = false
+newest = true
 download-cache = downloads
 log-level = INFO
 

--- a/buildout/ncwms2/environment.yml
+++ b/buildout/ncwms2/environment.yml
@@ -4,7 +4,7 @@ channels:
   - birdhouse
   - conda-forge
 dependencies:
-  - python=2.7.13
+  - python=3.6
   - setuptools=27.2.0
   - pyyaml
 # ncwms

--- a/buildout/ncwms2/environment.yml
+++ b/buildout/ncwms2/environment.yml
@@ -2,6 +2,7 @@ name: ncwms2
 channels:
   - defaults
   - birdhouse
+  - conda-forge
 dependencies:
   - python=2.7.13
   - setuptools=27.2.0

--- a/buildout/ncwms2/environment.yml
+++ b/buildout/ncwms2/environment.yml
@@ -5,7 +5,7 @@ channels:
   - conda-forge
 dependencies:
   - python=3.6
-  - setuptools=27.2.0
+  - setuptools=36.4.0
   - pyyaml
 # ncwms
   - ncwms2=2.2.8

--- a/buildout/ncwms2/requirements/conda_pinned
+++ b/buildout/ncwms2/requirements/conda_pinned
@@ -1,1 +1,1 @@
-python =3.6
+python 3.6

--- a/buildout/ncwms2/requirements/conda_pinned
+++ b/buildout/ncwms2/requirements/conda_pinned
@@ -1,1 +1,1 @@
-python <3
+python =3.6

--- a/buildout/ncwms2/versions.cfg
+++ b/buildout/ncwms2/versions.cfg
@@ -2,18 +2,18 @@
 MarkupSafe = 0.23
 birdhousebuilder.recipe.conda = 0.3.6
 birdhousebuilder.recipe.ncwms = 0.4.1
-birdhousebuilder.recipe.supervisor = 0.3.5
+birdhousebuilder.recipe.supervisor = 0.3.6
 birdhousebuilder.recipe.tomcat = 0.3.3
 buildout.locallib = 0.3.1
 collective.recipe.environment = 0.2.0
-setuptools = 27.2.0
+setuptools = 36.4.0
 zc.recipe.deployment = 1.3.0
-zc.recipe.egg = 2.0.3
+zc.recipe.egg = 2.0.4
 
 # Required by:
 # birdhousebuilder.recipe.ncwms==0.4.1
 # birdhousebuilder.recipe.tomcat==0.3.3
-Mako = 1.0.6
+Mako = 1.0.7
 
 # Required by:
 # zc.recipe.deployment==1.3.0

--- a/buildout/ncwms2/versions.cfg
+++ b/buildout/ncwms2/versions.cfg
@@ -1,6 +1,6 @@
 [versions]
 MarkupSafe = 0.23
-birdhousebuilder.recipe.conda = 0.3.5
+birdhousebuilder.recipe.conda = 0.3.6
 birdhousebuilder.recipe.ncwms = 0.4.1
 birdhousebuilder.recipe.supervisor = 0.3.5
 birdhousebuilder.recipe.tomcat = 0.3.3

--- a/docker/adagucserver/buildout.cfg
+++ b/docker/adagucserver/buildout.cfg
@@ -2,7 +2,7 @@
 
 # buildout options
 show-picked-versions = true
-newest = false
+newest = true
 versions = versions
 download-cache = downloads
 log-level = INFO
@@ -22,7 +22,7 @@ http-port = 9002
 
 [versions]
 birdhousebuilder.recipe.adagucserver = 0.3.4
-birdhousebuilder.recipe.docker = 0.4.8
+birdhousebuilder.recipe.docker = 0.5.3
 
 [adagucserver]
 recipe = birdhousebuilder.recipe.adagucserver

--- a/docker/mongodb/Dockerfile
+++ b/docker/mongodb/Dockerfile
@@ -2,7 +2,7 @@
 FROM birdhouse/bird-base:latest
 MAINTAINER https://github.com/bird-house/birdhouse-playground/tree/master/mongodb
 
-LABEL Description="MongoDB NoSQL Database" Vendor="MongoDB" Version="2.4.6"
+LABEL Description="MongoDB NoSQL Database" Vendor="MongoDB" Version="3.3.9"
 
 # Configure hostname and user for services 
 ENV HOSTNAME localhost

--- a/docker/mongodb/buildout.cfg
+++ b/docker/mongodb/buildout.cfg
@@ -2,7 +2,7 @@
 
 # buildout options
 show-picked-versions = true
-newest = false
+newest = true
 versions = versions
 download-cache = downloads
 log-level = INFO
@@ -22,18 +22,18 @@ bind-ip = 127.0.0.1
 port = 27027
 
 [versions]
-birdhousebuilder.recipe.docker = 0.4.8
-birdhousebuilder.recipe.mongodb = 0.2.2
+birdhousebuilder.recipe.docker = 0.5.3
+birdhousebuilder.recipe.mongodb = 0.4.0
 buildout.locallib = 0.3.1
 
 # Required by:
 # birdhousebuilder.recipe.mongodb==0.2.2
 # birdhousebuilder.recipe.supervisor==0.2.6
-birdhousebuilder.recipe.conda = 0.2.6
+birdhousebuilder.recipe.conda = 0.3.6
 
 # Required by:
 # birdhousebuilder.recipe.mongodb==0.2.2
-birdhousebuilder.recipe.supervisor = 0.2.8
+birdhousebuilder.recipe.supervisor = 0.3.6
 
 [mongodb]
 recipe = birdhousebuilder.recipe.mongodb
@@ -45,7 +45,7 @@ recipe = birdhousebuilder.recipe.docker
 vendor = MongoDB
 maintainer = https://github.com/bird-house/birdhouse-playground/tree/master/mongodb
 description = MongoDB NoSQL Database
-version = 2.4.6
+version = 3.3.9
 git-url = https://github.com/bird-house/birdhouse-playground
 subdir = mongodb
 command = make start

--- a/docker/ncwms2/.docker.cfg
+++ b/docker/ncwms2/.docker.cfg
@@ -6,3 +6,7 @@ supervisor-port = 9001
 
 [settings]
 
+## deployment options for debian os
+prefix = /opt/birdhouse
+user = www-data
+etc-user = root

--- a/docker/ncwms2/.gitignore
+++ b/docker/ncwms2/.gitignore
@@ -6,6 +6,7 @@
 
 # custom configs
 custom.cfg
+Makefile.config
 
 # Python / Extensions etc.
 *~
@@ -17,17 +18,25 @@ custom.cfg
 *.egg-info
 *.sqlite
 *.bak
+__pycache__
 
 # Unit test / Coverage reports
+.cache
 .coverage
 .tox
 nosetests.xml
 unit_tests/testdata.json
 
+# R 
+*.Rhistory
+
 # Eclipse / PyDev
 .project
 .pydevproject
 .settings
+
+# PyCharm
+*.idea
 
 # Kate
 *.kate-swp
@@ -66,3 +75,11 @@ testdata.json
 
 # IPython
 .ipynb_checkpoints
+
+# gcc/fortran
+*.o
+*.a
+*.mod
+*.out
+
+

--- a/docker/ncwms2/Dockerfile
+++ b/docker/ncwms2/Dockerfile
@@ -2,7 +2,7 @@
 FROM birdhouse/bird-base:latest
 MAINTAINER https://github.com/bird-house/birdhouse-playground/tree/master/ncwms2
 
-LABEL Description="ncWMS2 Web Map Service" Vendor="Reading eScience Centre" Version="2.2.2"
+LABEL Description="ncWMS2 Web Map Service" Vendor="Reading eScience Centre" Version="2.2.8"
 
 # Configure hostname and user for services 
 ENV HOSTNAME localhost

--- a/docker/ncwms2/Dockerfile
+++ b/docker/ncwms2/Dockerfile
@@ -2,7 +2,7 @@
 FROM birdhouse/bird-base:latest
 MAINTAINER https://github.com/bird-house/birdhouse-playground/tree/master/ncwms2
 
-LABEL Description="ncWMS2 Web Map Service" Vendor="Reading eScience Centre" Version="2.0.4"
+LABEL Description="ncWMS2 Web Map Service" Vendor="Reading eScience Centre" Version="2.2.2"
 
 # Configure hostname and user for services 
 ENV HOSTNAME localhost

--- a/docker/ncwms2/Makefile
+++ b/docker/ncwms2/Makefile
@@ -149,6 +149,7 @@ conda_config: anaconda
 	@"$(ANACONDA_HOME)/bin/conda" config --add channels defaults
 	@"$(ANACONDA_HOME)/bin/conda" config --add channels birdhouse
 	@"$(ANACONDA_HOME)/bin/conda" config --add channels ioos
+	@"$(ANACONDA_HOME)/bin/conda" config --add channels conda-forge
 
 .PHONY: conda_env
 conda_env: anaconda conda_config

--- a/docker/ncwms2/Makefile
+++ b/docker/ncwms2/Makefile
@@ -14,6 +14,7 @@ ANACONDA_HOME ?= $(HOME)/anaconda
 CONDA_ENV := birdhouse
 CONDA_ENVS_DIR ?= $(HOME)/.conda/envs
 PREFIX := $(CONDA_ENVS_DIR)/$(CONDA_ENV)
+PYTHON_VERSION_MAJOR := 3
 
 # Configuration used by update-config
 HOSTNAME ?= localhost
@@ -24,7 +25,13 @@ LOG_LEVEL ?= WARN
 # choose anaconda installer depending on your OS
 ANACONDA_URL = http://repo.continuum.io/miniconda
 ifeq "$(OS_NAME)" "Linux"
-FN := Miniconda-latest-Linux-x86_64.sh
+ifeq "$(PYTHON_VERSION_MAJOR)" "2"
+FN := Miniconda2-latest-Linux-x86_64.sh
+else ifeq "$(PYTHON_VERSION_MAJOR)" "3"
+FN := Miniconda3-latest-Linux_x86_64.sh
+else
+FN := unknown
+endif
 else ifeq "$(OS_NAME)" "Darwin"
 FN := Miniconda-3.7.0-MacOSX-x86_64.sh
 else
@@ -82,16 +89,17 @@ version:
 .PHONY: info
 info:
 	@echo "Informations about your System:\n"
-	@echo "\t OS_NAME          \t= $(OS_NAME)"
-	@echo "\t CPU_ARCH         \t= $(CPU_ARCH)"
-	@echo "\t Anaconda         \t= $(FN)"
-	@echo "\t Anaconda Home    \t= $(ANACONDA_HOME)"
-	@echo "\t Birdhouse Env    \t= $(PREFIX)"
-	@echo "\t APP_NAME         \t= $(APP_NAME)"
-	@echo "\t APP_ROOT         \t= $(APP_ROOT)"
-	@echo "\t DOWNLOAD_CACHE   \t= $(DOWNLOAD_CACHE)"
-	@echo "\t DOCKER_IMAGE     \t= $(DOCKER_IMAGE)"
-	@echo "\t DOCKER_CONTAINER \t= $(DOCKER_CONTAINER)"
+	@echo "\t OS_NAME          	\t= $(OS_NAME)"
+	@echo "\t CPU_ARCH         	\t= $(CPU_ARCH)"
+	@echo "\t Anaconda         	\t= $(FN)"
+	@echo "\t Anaconda Home    	\t= $(ANACONDA_HOME)"
+	@echo "\t Python Version Major 	\t= $(PYTHON_VERSION_MAJOR)"
+	@echo "\t Birdhouse Env    	\t= $(PREFIX)"
+	@echo "\t APP_NAME         	\t= $(APP_NAME)"
+	@echo "\t APP_ROOT         	\t= $(APP_ROOT)"
+	@echo "\t DOWNLOAD_CACHE   	\t= $(DOWNLOAD_CACHE)"
+	@echo "\t DOCKER_IMAGE     	\t= $(DOCKER_IMAGE)"
+	@echo "\t DOCKER_CONTAINER 	\t= $(DOCKER_CONTAINER)"
 
 ## Helper targets ... ensure that Makefile etc are in place
 

--- a/docker/ncwms2/Makefile
+++ b/docker/ncwms2/Makefile
@@ -169,7 +169,7 @@ conda_clean: anaconda conda_config
 .PHONY: bootstrap
 bootstrap: init conda_env conda_pinned bootstrap-buildout.py
 	@echo "Bootstrap buildout ..."
-	@test -f bin/buildout || bash -c "source $(ANACONDA_HOME)/bin/activate $(CONDA_ENV);python bootstrap-buildout.py -c custom.cfg --allow-site-packages --setuptools-version=17.1.1 --buildout-version=2.4.0"
+	@test -f bin/buildout || bash -c "source $(ANACONDA_HOME)/bin/activate $(CONDA_ENV);python bootstrap-buildout.py -c custom.cfg --allow-site-packages --setuptools-version=17.1.1"
 
 .PHONY: sysinstall
 sysinstall:

--- a/docker/ncwms2/buildout.cfg
+++ b/docker/ncwms2/buildout.cfg
@@ -41,6 +41,9 @@ birdhousebuilder.recipe.docker = 0.4.8
 
 [ncwms]
 recipe = birdhousebuilder.recipe.ncwms
+prefix = ${settings:prefix}
+user = ${settings:user}
+etc-user = ${settings:etc-user}
 # tomcat
 http_port = ${settings:http-port}
 Xms = ${settings:tomcat-xms}

--- a/docker/ncwms2/buildout.cfg
+++ b/docker/ncwms2/buildout.cfg
@@ -2,7 +2,7 @@
 
 # buildout options
 show-picked-versions = true
-newest = false
+newest = true
 versions = versions
 download-cache = downloads
 log-level = INFO
@@ -35,8 +35,8 @@ enablecache = false
 updateInterval = 1
 
 [versions]
-birdhousebuilder.recipe.ncwms = 0.2.0
-birdhousebuilder.recipe.tomcat = 0.2.9
+birdhousebuilder.recipe.ncwms = 0.3.1
+birdhousebuilder.recipe.tomcat = 0.3.3
 birdhousebuilder.recipe.docker = 0.4.8
 
 [ncwms]

--- a/docker/ncwms2/buildout.cfg
+++ b/docker/ncwms2/buildout.cfg
@@ -35,7 +35,8 @@ enablecache = false
 updateInterval = 1
 
 [versions]
-birdhousebuilder.recipe.ncwms = 0.3.1
+birdhousebuilder.recipe.conda = 0.3.6
+birdhousebuilder.recipe.ncwms = 0.4.1
 birdhousebuilder.recipe.tomcat = 0.3.3
 birdhousebuilder.recipe.docker = 0.4.8
 

--- a/docker/ncwms2/buildout.cfg
+++ b/docker/ncwms2/buildout.cfg
@@ -68,7 +68,7 @@ vendor = Reading eScience Centre
 maintainer = https://github.com/bird-house/birdhouse-playground/tree/master/ncwms2
 description = ncWMS2 Web Map Service
 command = make update-config update-user start
-version = 2.2.2
+version = 2.2.8
 expose = 8080
 
            

--- a/docker/ncwms2/buildout.cfg
+++ b/docker/ncwms2/buildout.cfg
@@ -38,7 +38,7 @@ updateInterval = 1
 birdhousebuilder.recipe.conda = 0.3.6
 birdhousebuilder.recipe.ncwms = 0.4.1
 birdhousebuilder.recipe.tomcat = 0.3.3
-birdhousebuilder.recipe.docker = 0.4.8
+birdhousebuilder.recipe.docker = 0.5.3
 
 [ncwms]
 recipe = birdhousebuilder.recipe.ncwms
@@ -68,7 +68,7 @@ vendor = Reading eScience Centre
 maintainer = https://github.com/bird-house/birdhouse-playground/tree/master/ncwms2
 description = ncWMS2 Web Map Service
 command = make update-config update-user start
-version = 2.0.4
+version = 2.2.2
 expose = 8080
 
            

--- a/docker/pycsw/buildout.cfg
+++ b/docker/pycsw/buildout.cfg
@@ -24,7 +24,7 @@ allowed-ips = 127.0.0.1
 transactions = true
 
 [versions]
-birdhousebuilder.recipe.docker = 0.4.8
+birdhousebuilder.recipe.docker = 0.5.3
 birdhousebuilder.recipe.pycsw = 0.3.0
 buildout.locallib = 0.3.1
 
@@ -32,16 +32,16 @@ buildout.locallib = 0.3.1
 # birdhousebuilder.recipe.nginx==0.2.3
 # birdhousebuilder.recipe.pycsw==0.2.2
 # birdhousebuilder.recipe.supervisor==0.2.6
-birdhousebuilder.recipe.conda = 0.2.6
+birdhousebuilder.recipe.conda = 0.3.6
 
 # Required by:
 # birdhousebuilder.recipe.pycsw==0.2.2
-birdhousebuilder.recipe.nginx = 0.2.3
+birdhousebuilder.recipe.nginx = 0.3.6
 
 # Required by:
 # birdhousebuilder.recipe.nginx==0.2.3
 # birdhousebuilder.recipe.pycsw==0.2.2
-birdhousebuilder.recipe.supervisor = 0.2.8
+birdhousebuilder.recipe.supervisor = 0.3.6
 
 
 [pycsw]

--- a/docker/pycsw/buildout.cfg
+++ b/docker/pycsw/buildout.cfg
@@ -2,7 +2,7 @@
 
 # buildout options
 show-picked-versions = true
-newest = false
+newest = true
 versions = versions
 download-cache = downloads
 log-level = INFO

--- a/docker/redis/Dockerfile
+++ b/docker/redis/Dockerfile
@@ -2,7 +2,7 @@
 FROM birdhouse/bird-base:latest
 MAINTAINER https://github.com/bird-house/birdhouse-playground/tree/master/redis
 
-LABEL Description="Redis in-memory data structure store" Vendor="Redis" Version="3.0.3"
+LABEL Description="Redis in-memory data structure store" Vendor="Redis" Version="3.2.0"
 
 # Configure hostname and user for services 
 ENV HOSTNAME localhost

--- a/docker/redis/buildout.cfg
+++ b/docker/redis/buildout.cfg
@@ -2,7 +2,7 @@
 
 # buildout options
 show-picked-versions = true
-newest = false
+newest = true
 versions = versions
 download-cache = downloads
 log-level = INFO
@@ -22,7 +22,7 @@ http-port = 6379
 
 [versions]
 birdhousebuilder.recipe.redis = 0.1.0
-birdhousebuilder.recipe.docker = 0.4.8
+birdhousebuilder.recipe.docker = 0.5.3
 
 [redis]
 recipe = birdhousebuilder.recipe.redis
@@ -33,7 +33,7 @@ recipe = birdhousebuilder.recipe.docker
 vendor = Redis
 maintainer = https://github.com/bird-house/birdhouse-playground/tree/master/redis
 description = Redis in-memory data structure store
-version = 3.0.3
+version = 3.2.0
 git-url = https://github.com/bird-house/birdhouse-playground
 subdir = redis
 command = make start

--- a/docker/solr/Makefile
+++ b/docker/solr/Makefile
@@ -168,7 +168,7 @@ conda_clean: anaconda conda_config
 .PHONY: bootstrap
 bootstrap: init conda_env conda_pinned bootstrap-buildout.py
 	@echo "Bootstrap buildout ..."
-	@test -f bin/buildout || bash -c "source $(ANACONDA_HOME)/bin/activate $(CONDA_ENV);python bootstrap-buildout.py -c custom.cfg --allow-site-packages --setuptools-version=17.1.1 --buildout-version=2.4.0"
+	@test -f bin/buildout || bash -c "source $(ANACONDA_HOME)/bin/activate $(CONDA_ENV);python bootstrap-buildout.py -c custom.cfg --allow-site-packages --setuptools-version=17.1.1"
 
 .PHONY: sysinstall
 sysinstall:

--- a/docker/solr/buildout.cfg
+++ b/docker/solr/buildout.cfg
@@ -2,7 +2,7 @@
 
 # buildout options
 show-picked-versions = true
-newest = false
+newest = true
 versions = versions
 download-cache = downloads
 log-level = INFO
@@ -22,18 +22,18 @@ hostname = localhost
 http-port = 8983
 
 [versions]
-birdhousebuilder.recipe.docker = 0.4.8
-birdhousebuilder.recipe.solr = 0.1.5
+birdhousebuilder.recipe.docker = 0.5.3
+birdhousebuilder.recipe.solr = 0.2.2
 buildout.locallib = 0.3.1
 
 # Required by:
 # birdhousebuilder.recipe.solr==0.1.4
 # birdhousebuilder.recipe.supervisor==0.2.6
-birdhousebuilder.recipe.conda = 0.2.6
+birdhousebuilder.recipe.conda = 0.3.6
 
 # Required by:
 # birdhousebuilder.recipe.solr==0.1.4
-birdhousebuilder.recipe.supervisor = 0.2.8
+birdhousebuilder.recipe.supervisor = 0.3.6
 
 [solr]
 recipe = birdhousebuilder.recipe.solr

--- a/docker/thredds/Dockerfile
+++ b/docker/thredds/Dockerfile
@@ -2,7 +2,7 @@
 FROM birdhouse/bird-base:latest
 MAINTAINER https://github.com/bird-house/birdhouse-playground/tree/master/thredds
 
-LABEL Description="Thredds data server" Vendor="Unidata" Version="4.6.2"
+LABEL Description="Thredds data server" Vendor="Unidata" Version="4.6.10"
 
 # Configure hostname and user for services 
 ENV HOSTNAME localhost

--- a/docker/thredds/buildout.cfg
+++ b/docker/thredds/buildout.cfg
@@ -2,7 +2,7 @@
 
 # buildout options
 show-picked-versions = true
-newest = false
+newest = true
 versions = versions
 download-cache = downloads
 log-level = INFO
@@ -25,19 +25,19 @@ tomcat-maxpermsize = 128m
 tomcat-ncwms-password =
 
 [versions]
-birdhousebuilder.recipe.docker = 0.4.8
+birdhousebuilder.recipe.docker = 0.5.3
 birdhousebuilder.recipe.thredds = 0.3.0
-birdhousebuilder.recipe.tomcat = 0.2.9
+birdhousebuilder.recipe.tomcat = 0.3.3
 buildout.locallib = 0.3.1
 
 # Required by:
 # birdhousebuilder.recipe.supervisor==0.2.6
 # birdhousebuilder.recipe.tomcat==0.2.8
-birdhousebuilder.recipe.conda = 0.2.5
+birdhousebuilder.recipe.conda = 0.3.6
 
 # Required by:
 # birdhousebuilder.recipe.tomcat==0.2.8
-birdhousebuilder.recipe.supervisor = 0.2.8
+birdhousebuilder.recipe.supervisor = 0.3.6
 
 [thredds]
 recipe = birdhousebuilder.recipe.thredds
@@ -54,7 +54,7 @@ recipe = birdhousebuilder.recipe.docker
 vendor = Unidata
 maintainer = https://github.com/bird-house/birdhouse-playground/tree/master/thredds
 description = Thredds data server
-version = 4.6.2
+version = 4.6.10
 command = make update-config update-user start
 expose = 8080
 


### PR DESCRIPTION
This PR resolves some errors encountered with external packages that use this project in combination with docker images and ncWMS. Missing variables and settings where making any build of this package impossible on docker since version ~2.0.4 (see [docker ncwms2 builds](https://hub.docker.com/r/birdhouse/ncwms2/builds/)).
The PR makes it possible to pull the latest version without affecting other components.

### DONE

* add missing conda-forge channel where required
* add missing dockerfile-compose settings where required
* tested whole package build/install process

#### Note 

Python version variable added to makefile for future selection, but "birdhousebuilder.recipe.conda" seems to enforce Py2 no matter which "miniconda" sh file is employed. 